### PR TITLE
fix package.json and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Insert the below configuration into `coffeelint.json` that you use for linting y
 
 ```json
 "advanced_colon_assignment_spacing": {
-  "module": "advanced_colon_assignment_spacing",
+  "module": "coffeelint-advanced-colon-assignment-spacing",
   "level": "error",
   "spacing": {
     "left": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "coffeelint-advanced-colon-assignment-spacing",
   "version": "0.0.1",
   "description": "Validate a spacing left and right of a colon assignment",
-  "main": "index.js",
+  "main": "index.coffee",
   "repository": {
     "type": "git",
     "url": "https://github.com/levibuzolic/coffeelint-advanced-colon-assignment-spacing.git"
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/levibuzolic/coffeelint-advanced-colon-assignment-spacing",
   "peerDependencies": {
-    "coffeelint": "~1.3"
+    "coffeelint": "1.x"
   },
   "devDependencies": {
     "coffee-script": "~1.7.0"


### PR DESCRIPTION
Hi, thanks for this great rule. I wanted to use it and noticed that I could not load it. I fixed the peerDeps and specified the correct main file which is `index.coffee`. I also had to update the instructions in the readme because your example did not work with the underscores `_`. I had to use hyphens for module loading.

I guess that when this is merged issue #2 will be resolved. The Plugin works fine for me with coffeelint version 1.11.1
